### PR TITLE
Update pdu_utilsConfig.cmake

### DIFF
--- a/cmake/Modules/pdu_utilsConfig.cmake
+++ b/cmake/Modules/pdu_utilsConfig.cmake
@@ -24,7 +24,7 @@ FIND_LIBRARY(
           /usr/lib64
           )
 
-include("${CMAKE_CURRENT_LIST_DIR}/pdu_utilsTarget.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/gnuradio-pdu_utilsTargets.cmake")
 
 INCLUDE(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(PDU_UTILS DEFAULT_MSG PDU_UTILS_LIBRARIES PDU_UTILS_INCLUDE_DIRS)


### PR DESCRIPTION
Update pdu_utilsTargets.cmake to gnuradio-pdu_utilsTargets.cmake. I'm not sure when the change happened but I needed to do this to compile against it.