### PR TITLE
Update pdu_set_m_impl.cc

### DIFF
--- a/lib/pdu_set_m_impl.cc
+++ b/lib/pdu_set_m_impl.cc
@@ -37,10 +37,10 @@ pdu_set_m_impl::pdu_set_m_impl(pmt::pmt_t k, pmt::pmt_t v, bool kv_merge, bool v
 {
     message_port_register_in(PMTCONSTSTR__pdu_in());
     set_msg_handler(PMTCONSTSTR__pdu_in(),
-                    boost::bind(&pdu_set_m_impl::handle_msg, this, _1));
+                    boost::bind(&pdu_set_m_impl::handle_msg, this, boost::placeholders::_1));
     message_port_register_in(PMTCONSTSTR__ctrl());
     set_msg_handler(PMTCONSTSTR__ctrl(),
-                    boost::bind(&pdu_set_m_impl::handle_ctrl_msg, this, _1));
+                    boost::bind(&pdu_set_m_impl::handle_ctrl_msg, this, boost::placeholders::_1));
     message_port_register_out(PMTCONSTSTR__pdu_out());
 }
 


### PR DESCRIPTION
fixed: build failure: error: ‘_1’ was not declared in this scope

this error raised on gr version 3.8, 3.9, 3.10, 3.11