### PR TITLE
fix error with out of date message handler syntax

### DIFF
--- a/lib/pdu_set_m_impl.cc
+++ b/lib/pdu_set_m_impl.cc
@@ -37,10 +37,10 @@ pdu_set_m_impl::pdu_set_m_impl(pmt::pmt_t k, pmt::pmt_t v, bool kv_merge, bool v
 {
     message_port_register_in(PMTCONSTSTR__pdu_in());
     set_msg_handler(PMTCONSTSTR__pdu_in(),
-                    boost::bind(&pdu_set_m_impl::handle_msg, this, _1));
+                    [this](pmt::pmt_t msg) { this->handle_msg(msg); });
     message_port_register_in(PMTCONSTSTR__ctrl());
     set_msg_handler(PMTCONSTSTR__ctrl(),
-                    boost::bind(&pdu_set_m_impl::handle_ctrl_msg, this, _1));
+                    [this](pmt::pmt_t msg) { this->handle_ctrl_msg(msg); });
     message_port_register_out(PMTCONSTSTR__pdu_out());
 }
 


### PR DESCRIPTION
fixes this error (w/o boost):

```
[  1%] Building CXX object lib/CMakeFiles/gnuradio-pdu_utils.dir/pdu_set_m_impl.cc.o
/opt/gnuradio310/src/gr-pdu_utils/lib/pdu_set_m_impl.cc: In constructor ‘gr::pdu_utils::pdu_set_m_impl::pdu_set_m_impl(pmt::pmt_t, pmt::pmt_t, bool, bool)’:
/opt/gnuradio310/src/gr-pdu_utils/lib/pdu_set_m_impl.cc:40:68: error: ‘_1’ was not declared in this scope
   40 |                     boost::bind(&pdu_set_m_impl::handle_msg, this, _1));
      |                                                                    ^~
```