### PR TITLE
Fix boost missing format import

### DIFF
--- a/lib/access_code_to_pdu_impl.cc
+++ b/lib/access_code_to_pdu_impl.cc
@@ -16,7 +16,7 @@
 #include <gnuradio/pdu_utils/constants.h>
 #include <volk/volk.h>
 #include <bitset>
-
+#include <boost/format.hpp>
 namespace gr {
 namespace pdu_utils {
 

--- a/lib/access_code_to_pdu_impl.cc
+++ b/lib/access_code_to_pdu_impl.cc
@@ -62,16 +62,13 @@ access_code_to_pdu_impl::access_code_to_pdu_impl(std::string access_code,
 
     // throw error if access code is empty and strict mode is not on
     if (d_access_len == 0 && d_readmode != READ_STRICT) {
-        GR_LOG_ERROR(
-            d_logger,
-            boost::format("access code should not be empty outside of strict mode"));
+        d_logger->error("access code should not be empty outside of strict mode");
         throw std::runtime_error("");
     }
 
     // make sure burst length is at least the size of the sum of the syncwords
     if (d_burst_len < d_access_len + d_tail_len) {
-        GR_LOG_ERROR(d_logger,
-                     boost::format("total burst length shorter than syncword(s)"));
+        d_logger->error("total burst length shorter than syncword(s)");
         throw std::runtime_error("");
     }
 
@@ -125,19 +122,15 @@ void access_code_to_pdu_impl::set_sync(const std::string sync_string,
         syncword_len = (is_hex) ? 4 * (syncword_len - 2) : syncword_len;
         mask_int = (syncword_len >= 64 ? -1 : (1lu << syncword_len) - 1);
     } catch (std::invalid_argument& ex) {
-        GR_LOG_ERROR(
-            d_logger,
-            boost::format("unable to parse syncword '%s' (must be base 2 or 16)") %
+        d_logger->error("unable to parse syncword '{}' (must be base 2 or 16)",
                 syncword.c_str());
         throw std::runtime_error("");
     } catch (std::out_of_range& ex) {
-        GR_LOG_ERROR(d_logger,
-                     boost::format("syncword '%s' out of range (max of 64 bits)") %
+        d_logger->error("syncword '{}' out of range (max of 64 bits)",
                          syncword.c_str());
         throw std::runtime_error("");
     }
-    GR_LOG_DEBUG(d_logger,
-                 boost::format("syncword: 0x%016lX (mask 0x%016lX)") % syncword_int %
+    d_logger->debug("syncword: {:#+16X} (mask {:#+16X})",syncword_int,
                      mask_int);
     *sync = syncword_int;
     *mask = mask_int;

--- a/lib/extract_metadata_impl.cc
+++ b/lib/extract_metadata_impl.cc
@@ -78,32 +78,26 @@ void extract_metadata_impl::handle_msg(pmt::pmt_t msg)
                 try {
                     value = pmt::from_double(pmt::to_double(value) * d_scale + d_offset);
                 } catch (const pmt::wrong_type& e) {
-                    GR_LOG_ERROR(d_logger, "was real...but double() failed");
+                    d_logger->error("was real...but double() failed");
                 }
             } else if (pmt::is_uint64(value)) {
                 try {
                     value = pmt::from_uint64(
                         uint64_t(pmt::to_uint64(value) * d_scale + d_offset));
                 } catch (const pmt::wrong_type& e) {
-                    GR_LOG_ERROR(d_logger,
-                                 boost::format("something went wrong getting uint64") %
-                                     value);
+                    d_logger->error("something went wrong getting uint64 {}",uint64_t(pmt::to_uint64(value) * d_scale + d_offset));
                 }
             } else if (pmt::is_integer(value)) {
                 try {
                     value =
                         pmt::from_long(long(pmt::to_long(value) * d_scale + d_offset));
                 } catch (const pmt::wrong_type& e) {
-                    GR_LOG_ERROR(d_logger,
-                                 boost::format("something went wrong getting long") %
-                                     value);
+                    d_logger->error("something went wrong getting long {}",long(pmt::to_long(value) * d_scale + d_offset));
                 }
             } else if (pmt::is_complex(value)) {
                 ;
             } else {
-                GR_LOG_ERROR(
-                    d_logger,
-                    boost::format("got a number...but not an int, real, complex"));
+                d_logger->error("got a number...but not an int, real, complex");
             }
         }
 

--- a/lib/extract_metadata_impl.cc
+++ b/lib/extract_metadata_impl.cc
@@ -13,7 +13,7 @@
 
 #include "extract_metadata_impl.h"
 #include <gnuradio/io_signature.h>
-
+#include <boost/format.hpp>
 namespace gr {
 namespace pdu_utils {
 

--- a/lib/message_emitter_impl.cc
+++ b/lib/message_emitter_impl.cc
@@ -13,7 +13,7 @@
 
 #include "message_emitter_impl.h"
 #include <gnuradio/io_signature.h>
-
+#include <boost/format.hpp>
 namespace gr {
 namespace pdu_utils {
 

--- a/lib/message_emitter_impl.cc
+++ b/lib/message_emitter_impl.cc
@@ -47,7 +47,7 @@ message_emitter_impl::~message_emitter_impl() {}
  */
 bool message_emitter_impl::stop()
 {
-    GR_LOG_INFO(d_logger, boost::format("Message emitter sent %d messages") % d_n_msgs);
+    d_logger->info("Message emitter sent {} messages",d_n_msgs);
 
     return true;
 }

--- a/lib/message_gate_impl.cc
+++ b/lib/message_gate_impl.cc
@@ -47,9 +47,8 @@ message_gate_impl::~message_gate_impl() {}
  */
 bool message_gate_impl::stop()
 {
-    GR_LOG_INFO(d_logger,
-                boost::format("Message gate passed %d messages and blocked %d messages") %
-                    d_n_passed % d_n_blocked);
+    d_logger->info("Message gate passed {} messages and blocked {} messages",
+                    d_n_passed,d_n_blocked);
     return true;
 }
 

--- a/lib/message_gate_impl.cc
+++ b/lib/message_gate_impl.cc
@@ -13,7 +13,7 @@
 
 #include "message_gate_impl.h"
 #include <gnuradio/io_signature.h>
-
+#include <boost/format.hpp>
 namespace gr {
 namespace pdu_utils {
 

--- a/lib/message_keep_1_in_n_impl.cc
+++ b/lib/message_keep_1_in_n_impl.cc
@@ -13,7 +13,7 @@
 
 #include "message_keep_1_in_n_impl.h"
 #include <gnuradio/io_signature.h>
-
+#include <boost/format.hpp>
 namespace gr {
 namespace pdu_utils {
 

--- a/lib/message_keep_1_in_n_impl.cc
+++ b/lib/message_keep_1_in_n_impl.cc
@@ -68,7 +68,7 @@ void message_keep_1_in_n_impl::set_n(uint32_t n)
     if (n) {
         d_n = n;
     } else {
-        GR_LOG_ERROR(d_logger, boost::format("n cannot be zero, not set (n=%d)") % d_n);
+        d_logger->error("n cannot be zero, not set (n={})",d_n);
     }
 }
 

--- a/lib/msg_drop_random_impl.cc
+++ b/lib/msg_drop_random_impl.cc
@@ -13,7 +13,7 @@
 
 #include "msg_drop_random_impl.h"
 #include <gnuradio/io_signature.h>
-
+#include <boost/format.hpp>
 namespace gr {
 namespace pdu_utils {
 

--- a/lib/msg_drop_random_impl.cc
+++ b/lib/msg_drop_random_impl.cc
@@ -47,9 +47,8 @@ msg_drop_random_impl::~msg_drop_random_impl() {}
 
 bool msg_drop_random_impl::stop(void)
 {
-    GR_LOG_INFO(d_logger,
-                boost::format("Dropped %s messages, passed %d (%d total)") % d_drop_ctr %
-                    d_pass_ctr % d_msg_ctr);
+    d_logger->info("Dropped {} messages, passed {} ({} total)",d_drop_ctr,
+                    d_pass_ctr,d_msg_ctr);
     return true;
 }
 

--- a/lib/pack_unpack_impl.cc
+++ b/lib/pack_unpack_impl.cc
@@ -36,13 +36,13 @@ pack_unpack_impl::pack_unpack_impl(uint32_t mode, uint32_t bit_order)
     message_port_register_out(PMTCONSTSTR__pdu_out());
 
     if (d_mode == MODE_UNPACK_BYTE) {
-        GR_LOG_INFO(d_logger, "PDU Pack/Unpack instantiated in UNPACK BYTE mode");
+        d_logger->info("PDU Pack/Unpack instantiated in UNPACK BYTE mode");
     } else if (d_mode == MODE_PACK_BYTE) {
-        GR_LOG_INFO(d_logger, "PDU Pack/Unpack instantiated in PACK BYTE mode");
+        d_logger->info("PDU Pack/Unpack instantiated in PACK BYTE mode");
     } else if (d_mode == MODE_BITSWAP_BYTE) {
-        GR_LOG_INFO(d_logger, "PDU Pack/Unpack instantiated in BITSWAP mode");
+        d_logger->info("PDU Pack/Unpack instantiated in BITSWAP mode");
     } else {
-        GR_LOG_WARN(d_logger, "PDU Pack/Unpack instantiated in UNKNOWN mode");
+        d_logger->warn("PDU Pack/Unpack instantiated in UNKNOWN mode");
     }
 }
 
@@ -56,7 +56,7 @@ void pack_unpack_impl::handle_msg(pmt::pmt_t pdu)
 {
     // make sure PDU data is formed properly
     if (!(pmt::is_pair(pdu))) {
-        GR_LOG_NOTICE(d_logger, "received unexpected PMT (non-pair)");
+        d_logger->notice("received unexpected PMT (non-pair)");
         return;
     }
 
@@ -66,7 +66,7 @@ void pack_unpack_impl::handle_msg(pmt::pmt_t pdu)
     pmt::pmt_t v_data = pmt::cdr(pdu);
 
     if (!(is_dict(meta) && pmt::is_uniform_vector(v_data))) {
-        GR_LOG_NOTICE(d_logger, "received unexpected PMT (non-PDU)");
+        d_logger->notice("received unexpected PMT (non-PDU)");
         return;
     }
 
@@ -79,7 +79,7 @@ void pack_unpack_impl::handle_msg(pmt::pmt_t pdu)
          * input can be any byte vector.
          */
         if (!pmt::is_u8vector(v_data)) {
-            GR_LOG_ERROR(d_logger, "PDU vector is not uint8, dropping");
+            d_logger->error("PDU vector is not uint8, dropping");
             return;
         }
         const std::vector<uint8_t> data = pmt::u8vector_elements(v_data);
@@ -113,7 +113,7 @@ void pack_unpack_impl::handle_msg(pmt::pmt_t pdu)
          * Values other than zero will map to '1'.
          */
         if (!pmt::is_u8vector(v_data)) {
-            GR_LOG_ERROR(d_logger, "PDU vector is not uint8, dropping");
+            d_logger->error("PDU vector is not uint8, dropping");
             return;
         }
 
@@ -163,7 +163,7 @@ void pack_unpack_impl::handle_msg(pmt::pmt_t pdu)
          */
 
         if (!pmt::is_u8vector(v_data)) {
-            GR_LOG_ERROR(d_logger, "PDU vector is not uint8, dropping");
+            d_logger->error("PDU vector is not uint8, dropping");
             return;
         }
 
@@ -182,7 +182,7 @@ void pack_unpack_impl::handle_msg(pmt::pmt_t pdu)
         /*
          * All other modes are undefined... print a warning and drop PDU
          */
-        GR_LOG_WARN(d_logger, boost::format("Unknown block mode %d") % d_mode);
+        d_logger->warn("Unknown block mode {}",d_mode);
     }
 }
 

--- a/lib/pack_unpack_impl.cc
+++ b/lib/pack_unpack_impl.cc
@@ -13,7 +13,7 @@
 
 #include "pack_unpack_impl.h"
 #include <gnuradio/io_signature.h>
-
+#include <boost/format.hpp>
 namespace gr {
 namespace pdu_utils {
 

--- a/lib/pdu_align_impl.cc
+++ b/lib/pdu_align_impl.cc
@@ -16,6 +16,7 @@
 #include <gnuradio/pdu_utils/constants.h>
 #include <volk/volk.h>
 #include <boost/format.hpp>
+#include <bitset>
 
 namespace gr {
 namespace pdu_utils {

--- a/lib/pdu_align_impl.cc
+++ b/lib/pdu_align_impl.cc
@@ -71,21 +71,17 @@ pdu_align_impl::pdu_align_impl(std::string syncwords,
             mask_int = (syncword_len >= 64 ? -1 : (1lu << syncword_len) - 1);
             std::cout << "syncword_int = " << std::bitset<16>(syncword_int) << std::endl;
 	} catch (std::invalid_argument& ex) {
-            GR_LOG_ERROR(
-			 d_logger,
-                         boost::format("unable to parse syncword '%s' (must be base 2 or 16)") %
+            d_logger->error("unable to parse syncword '{}' (must be base 2 or 16)",
                              syncword.c_str());
             exit(1);
         } catch (std::out_of_range& ex) {
 
-            GR_LOG_ERROR(d_logger,
-                         boost::format("syncword '%s' out of range (max of 64 bits)") %
+            d_logger->error("syncword '{}' out of range (max of 64 bits)",
                              syncword.c_str());
             exit(1);
         }
-        GR_LOG_DEBUG(d_logger,
-                     boost::format("PDU align syncword: 0x%016lX (mask 0x%016lX)") %
-                         syncword_int % mask_int);
+        d_logger->debug("PDU align syncword: {:#+16X} (mask {:#+16X})",
+                         syncword_int, mask_int);
         d_syncwords.push_back(syncword_int);
         d_syncword_lens.push_back(syncword_len);
         d_masks.push_back(mask_int);
@@ -151,7 +147,7 @@ void pdu_align_impl::update_time_metadata(pmt::pmt_t& metadata, int start_idx)
 void pdu_align_impl::pdu_handler(pmt::pmt_t pdu)
 {
     if (!pmt::is_pair(pdu)) {
-        GR_LOG_DEBUG(d_logger, "WARNING: PDU is not a pair, dropping");
+        d_logger->debug("WARNING: PDU is not a pair, dropping");
         return;
     }
 
@@ -159,7 +155,7 @@ void pdu_align_impl::pdu_handler(pmt::pmt_t pdu)
     pmt::pmt_t pdu_data = pmt::cdr(pdu);
 
     if (!pmt::is_u8vector(pdu_data)) {
-        GR_LOG_DEBUG(d_logger, "WARNING: PDU not u8vector, dropping");
+        d_logger->debug("WARNING: PDU not u8vector, dropping");
         return;
     }
 
@@ -241,7 +237,7 @@ void pdu_align_impl::pdu_handler(pmt::pmt_t pdu)
     }
 
 
-    // GR_LOG_DEBUG(d_logger, "Syncword not found, dropping PDU");
+    // d_logger->debug("Syncword not found, dropping PDU");
 }
 
 } /* namespace pdu_utils */

--- a/lib/pdu_align_impl.cc
+++ b/lib/pdu_align_impl.cc
@@ -15,6 +15,7 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/pdu_utils/constants.h>
 #include <volk/volk.h>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace pdu_utils {

--- a/lib/pdu_burst_combiner_impl.cc
+++ b/lib/pdu_burst_combiner_impl.cc
@@ -14,7 +14,7 @@
 #include "pdu_burst_combiner_impl.h"
 #include "gnuradio/pdu_utils/constants.h"
 #include <gnuradio/io_signature.h>
-
+#include <boost/format.hpp>
 #include <cmath>
 
 

--- a/lib/pdu_burst_combiner_impl.cc
+++ b/lib/pdu_burst_combiner_impl.cc
@@ -56,7 +56,7 @@ void pdu_burst_combiner_impl::handle_pdu(pmt::pmt_t pdu)
 {
     // make sure PDU data is formed properly
     if (!(pmt::is_pair(pdu))) {
-        GR_LOG_NOTICE(d_logger, "received unexpected PMT (non-pair)");
+        d_logger->notice("received unexpected PMT (non-pair)");
         return;
     }
 
@@ -66,14 +66,14 @@ void pdu_burst_combiner_impl::handle_pdu(pmt::pmt_t pdu)
 
 
     if (!(is_dict(meta) && pmt::is_c32vector(v_data))) {
-        GR_LOG_WARN(d_logger, "PMT is not a complex PDU, dropping");
+        d_logger->warn("PMT is not a complex PDU, dropping");
         return;
     }
 
     uint32_t v_len = pmt::length(v_data);
 
     if (v_len == 0) {
-        GR_LOG_WARN(d_logger, "Zero length PDU, ignoring");
+        d_logger->warn("Zero length PDU, ignoring");
         return;
     }
 
@@ -90,26 +90,23 @@ void pdu_burst_combiner_impl::handle_pdu(pmt::pmt_t pdu)
         // we are in the middle of processing bursts...
         if (x > y) {
             // error...bad
-            GR_LOG_ALERT(
-                d_logger,
-                boost::format("Error processing PDU, burst_index metadata invalid (%)") %
-                    burst_index);
-            GR_LOG_ERROR(d_logger, "resetting state and dropping PDU");
+            std::ostringstream msg;
+            msg << boost::format("Error processing PDU, burst_index metadata invalid (%)") % burst_index;
+            d_logger->alert(msg.str());
+            d_logger->error("resetting state and dropping PDU");
             reset_state();
         } else if (x < y) {
             // not the last burst in the string
             const std::vector<gr_complex> d_in = pmt::c32vector_elements(v_data);
             d_data.insert(d_data.end(), d_in.begin(), d_in.end());
-            GR_LOG_DEBUG(d_logger,
-                         boost::format("saving PDU %d / %d! size is %d") % x % y %
+            d_logger->debug("saving PDU {} / {}! size is {}",x,y,
                              d_data.size());
 
         } else {
             // done with the burst, add new stuff and send it
             const std::vector<gr_complex> d_in = pmt::c32vector_elements(v_data);
             d_data.insert(d_data.end(), d_in.begin(), d_in.end());
-            GR_LOG_DEBUG(d_logger,
-                         boost::format("saving PDU %d / %d! size is %d") % x % y %
+            d_logger->debug("saving PDU {} / {}! size is {}",x,y,
                              d_data.size());
 
             message_port_pub(
@@ -127,17 +124,15 @@ void pdu_burst_combiner_impl::handle_pdu(pmt::pmt_t pdu)
                 reset_state();
                 const std::vector<gr_complex> d_in = pmt::c32vector_elements(v_data);
                 d_data.insert(d_data.end(), d_in.begin(), d_in.end());
-                GR_LOG_DEBUG(d_logger,
-                             boost::format("saving PDU %d / %d! size is %d") % x % y %
+                d_logger->debug("saving PDU {} / {}! size is {}",x,y,
                                  d_data.size());
 
                 d_burst_count = y;
                 d_burst0_metadata = meta;
 
             } else {
-                GR_LOG_ERROR(d_logger,
-                             "Error processing PDU, first burst does not have index = 1");
-                GR_LOG_ERROR(d_logger, "resetting state and dropping PDU");
+                d_logger->error("Error processing PDU, first burst does not have index = 1");
+                d_logger->error("resetting state and dropping PDU");
                 reset_state();
             }
         } else {

--- a/lib/pdu_clock_recovery_impl.cc
+++ b/lib/pdu_clock_recovery_impl.cc
@@ -14,7 +14,7 @@
 #include "pdu_clock_recovery_impl.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
-
+#include <boost/format.hpp>
 #include <algorithm>
 
 namespace gr {

--- a/lib/pdu_clock_recovery_impl.cc
+++ b/lib/pdu_clock_recovery_impl.cc
@@ -91,7 +91,7 @@ void pdu_clock_recovery_impl::set_window_type(window_type type)
 {
     d_window_type = type;
 
-    GR_LOG_INFO(d_logger, boost::format("Changing Window type %d") % d_window_type);
+    d_logger->info("Changing Window type {}",d_window_type);
 
     // flush all the existing pre-made memory & recreate it.
     fft_cleanup();
@@ -315,27 +315,21 @@ void pdu_clock_recovery_impl::pdu_handler(pmt::pmt_t pdu)
             }
         }
 
-        GR_LOG_DEBUG(d_logger,
-                     boost::format("BurstID %u, Input Sz: %d, FFT Power: %d, FFTSz: %d") %
-                         d_burst_id % length % fftpower % fftsize);
+        d_logger->debug("BurstID {}, Input Sz: {}, FFT Power: {}, FFTSz: {}",
+                         d_burst_id,length,fftpower,fftsize);
     }
 
     // calculate sample offset
     offset = (length - fftsize) / 2;
     if (d_debug) {
-        GR_LOG_DEBUG(d_logger,
-                     boost::format("BurstID %u sampLen:%d len:%d offset:%d") %
-                         d_burst_id % length % fftsize % offset);
+        d_logger->debug("BurstID {} sampLen:{} len:{} offset:{}",d_burst_id,length,fftsize,offset);
     }
 
     // make a list of zero crossing locations, offset
     std::vector<float> zero_crossings = findZeroCrossings(&data[offset], fftsize);
     if (zero_crossings.empty() || zero_crossings.size() < (size_t)(fftsize / (2 * SPS_MAX))) {
         if (d_debug) {
-            GR_LOG_WARN(
-                d_logger,
-                boost::format("BurstID %u no/low zero crossings found, dropping") %
-                    d_burst_id);
+            d_logger->warn("BurstID {} no/low zero crossings found, dropping", d_burst_id);
         }
         return;
     }
@@ -376,10 +370,8 @@ void pdu_clock_recovery_impl::pdu_handler(pmt::pmt_t pdu)
     float symbol_freq = peak_bin / fftsize / 2.0f;
 
     if (d_debug) {
-        GR_LOG_DEBUG(
-            d_logger,
-            boost::format("peak_bin %f   fftsize %d   symbol_freq %f    symbol_rate %f") %
-                peak_bin % fftsize % symbol_freq % (symbol_freq * samp_rate));
+        d_logger->debug("peak_bin {:e}   fftsize {}   symbol_freq {:e}    symbol_rate {:e}",
+                peak_bin,fftsize,symbol_freq,(symbol_freq * samp_rate));
     }
 
     // now extract soft symbols
@@ -445,7 +437,7 @@ bool pdu_clock_recovery_impl::inputCheck(pmt::pmt_t pdu)
 {
 
     if (!pmt::is_pair(pdu)) {
-        GR_LOG_WARN(d_logger, "PDU is not a pair, dropping\n");
+        d_logger->warn("PDU is not a pair, dropping\n");
         return false;
     }
 
@@ -453,19 +445,19 @@ bool pdu_clock_recovery_impl::inputCheck(pmt::pmt_t pdu)
     pmt::pmt_t pdu_data = pmt::cdr(pdu);
 
     if (!pmt::is_f32vector(pdu_data)) {
-        GR_LOG_WARN(d_logger, "PDU is not f32vector, dropping\n");
+        d_logger->warn("PDU is not f32vector, dropping\n");
         return false;
     }
 
     if (!pmt::is_dict(metadata)) {
-        GR_LOG_WARN(d_logger, "PDU metadata is not dict, dropping\n");
+        d_logger->warn("PDU metadata is not dict, dropping\n");
         return false;
     }
 
     pmt::pmt_t pmt_samp_rate =
         pmt::dict_ref(metadata, PMTCONSTSTR__sample_rate(), pmt::get_PMT_NIL());
     if (pmt_samp_rate == pmt::get_PMT_NIL() || !pmt::is_number(pmt_samp_rate)) {
-        GR_LOG_WARN(d_logger, "no sample rate, dropping\n");
+        d_logger->warn("no sample rate, dropping\n");
         return false;
     }
 
@@ -540,10 +532,9 @@ int pdu_clock_recovery_impl::findMaxFundamental(const float* mags, const int len
     float thresh = 0.5 * d_mags[max_bin];
 
     if (d_debug) {
-        GR_LOG_DEBUG(d_logger,
-                     boost::format("first pass max_bin %d(%f)   first_bin %d") % max_bin %
-                         d_mags[max_bin] % first_bin);
-        GR_LOG_DEBUG(d_logger, boost::format("harmonic thresh %f") % thresh);
+        d_logger->debug("first pass max_bin {}({:e})   first_bin {}",max_bin,
+                         d_mags[max_bin], first_bin);
+        d_logger->debug("harmonic thresh {:e}", thresh);
     }
 
 
@@ -558,9 +549,8 @@ int pdu_clock_recovery_impl::findMaxFundamental(const float* mags, const int len
         if (first_bin <= funIdx && funIdx < len) // avoid DC reject & inbounds
         {
             if (d_debug) {
-                GR_LOG_DEBUG(d_logger,
-                             boost::format("harmonic check %d(%f) thresh %f  denom %d") %
-                                 funIdx % d_mags[funIdx] % thresh % denom);
+                d_logger->debug("harmonic check {}({:e}) thresh {:e}  denom {}",
+                                 funIdx, d_mags[funIdx], thresh, denom);
             }
 
             if (d_mags[funIdx] >= thresh || d_mags[funIdx - 1] >= thresh ||
@@ -576,9 +566,8 @@ int pdu_clock_recovery_impl::findMaxFundamental(const float* mags, const int len
                 }
 
                 if (d_debug) {
-                    GR_LOG_DEBUG(d_logger,
-                                 boost::format("harmonic found, denom %d, bin %d(%f)") %
-                                     denom % max_bin % d_mags[max_bin]);
+                    d_logger->debug("harmonic found, denom {}, bin {}({:e})",
+                                     denom, max_bin, d_mags[max_bin]);
                 }
 
                 break;
@@ -590,8 +579,7 @@ int pdu_clock_recovery_impl::findMaxFundamental(const float* mags, const int len
     } // end for(denom
 
     if (d_debug) {
-        GR_LOG_DEBUG(d_logger,
-                     boost::format("second pass max_bin %d(%f)") % max_bin %
+        d_logger->debug("second pass max_bin {}({:e})", max_bin, 
                          d_mags[max_bin]);
     }
 
@@ -624,14 +612,10 @@ float pdu_clock_recovery_impl::calcPeakBin(const float* mags,
 
         if (std::isnan(ans) || std::isinf(ans) || (ans < 0)) {
             if (d_debug) {
-                GR_LOG_DEBUG(
-                    d_logger,
-                    boost::format("busrtID:%u peak_bin is inf or nan, reverting") %
+                d_logger->debug("burstID:{} peak_bin is inf or nan, reverting",
                         d_burst_id);
-                GR_LOG_DEBUG(
-                    d_logger,
-                    boost::format("burstID:%u max_bin:%d alpha:%f beta:%f gamma:%f") %
-                        d_burst_id % max_bin % alpha % beta % gamma);
+                d_logger->debug("burstID:{} max_bin:{} alpha:{:e} beta:{:e} gamma:{:e}",
+                        d_burst_id, max_bin, alpha, beta, gamma);
             }
             ans = max_bin;
         }
@@ -641,11 +625,8 @@ float pdu_clock_recovery_impl::calcPeakBin(const float* mags,
             // not a local maxima, i.e. a linear increasing/decreasing set of points
 
             if (d_debug) {
-                GR_LOG_DEBUG(
-                    d_logger,
-                    boost::format(
-                        "burstID:%u bin_offset outside sanity check %f, reverting") %
-                        d_burst_id % bin_offset);
+                d_logger->debug("burstID:{} bin_offset outside sanity check {:e}, reverting",
+                        d_burst_id, bin_offset);
             }
 
             ans = max_bin;
@@ -725,8 +706,7 @@ std::vector<float> pdu_clock_recovery_impl::extractSymbols(const float* data,
     // NOTE: The SincWaveform & FFT were not taken from the start of the file. We need to
     // offset clock_phase to account for this
     if (d_debug) {
-        GR_LOG_DEBUG(d_logger,
-                     boost::format("Pre correction phase %f   clock_phase %f") % phase %
+        d_logger->debug("Pre correction phase {:e}   clock_phase {:e}",phase,
                          clock_phase);
     }
     clock_phase -= offset * symbol_freq;
@@ -737,8 +717,7 @@ std::vector<float> pdu_clock_recovery_impl::extractSymbols(const float* data,
         clock_phase -= 1.0f;
     }
     if (d_debug) {
-        GR_LOG_DEBUG(d_logger,
-                     boost::format("phase %f   clock_phase %f") % phase % clock_phase);
+        d_logger->debug("phase {:e}   clock_phase {:e}", phase, clock_phase);
     }
 
 

--- a/lib/pdu_head_tail_impl.cc
+++ b/lib/pdu_head_tail_impl.cc
@@ -13,7 +13,7 @@
 
 #include "pdu_head_tail_impl.h"
 #include <gnuradio/io_signature.h>
-
+#include <boost/format.hpp>
 namespace gr {
 namespace pdu_utils {
 

--- a/lib/pdu_head_tail_impl.cc
+++ b/lib/pdu_head_tail_impl.cc
@@ -39,19 +39,19 @@ pdu_head_tail_impl::pdu_head_tail_impl(uint32_t input_type,
       d_bit_order(BIT_ORDER_LSB_FIRST)
 {
     if (d_input_type == INPUTTYPE_UNPACKED_BYTE) {
-        GR_LOG_DEBUG(d_logger, "PDU HEAD/TAIL block operating in Unpacked U8 PDU mode");
+        d_logger->debug("PDU HEAD/TAIL block operating in Unpacked U8 PDU mode");
     } else if (d_input_type == INPUTTYPE_PACKED_BYTE) {
-        // GR_LOG_DEBUG(d_logger, "PDU HEAD/TAIL block operating in 'Packed U8 PDU'
+        // d_logger->debug("PDU HEAD/TAIL block operating in 'Packed U8 PDU'
         // mode");
-        GR_LOG_FATAL(d_logger, "PACKED BYTE MODE NOT SUPPORTED YET");
+        d_logger->fatal("PACKED BYTE MODE NOT SUPPORTED YET");
         throw std::invalid_argument("invalid mode PACKED BYTE");
     } else if (d_input_type == INPUTTYPE_FLOAT) {
-        GR_LOG_DEBUG(d_logger, "PDU HEAD/TAIL block operating in FLOAT PDU mode");
+        d_logger->debug("PDU HEAD/TAIL block operating in FLOAT PDU mode");
     } else {
-        GR_LOG_FATAL(
-            d_logger,
-            boost::format("PDU HEAD/TAIL block instantiated in unknown mode %d") %
-                d_input_type);
+        std::ostringstream msg;
+        msg << boost::format("PDU HEAD/TAIL block instantiated in unknown mode %d") %
+                d_input_type;
+        d_logger->fatal(msg.str());
         throw std::invalid_argument("unknown mode");
     }
 

--- a/lib/pdu_length_filter_impl.cc
+++ b/lib/pdu_length_filter_impl.cc
@@ -50,9 +50,8 @@ pdu_length_filter_impl::~pdu_length_filter_impl() {}
  */
 bool pdu_length_filter_impl::stop()
 {
-    GR_LOG_INFO(d_logger,
-                boost::format("PDU length filter blocked %d and passed %d PDUs") %
-                    d_n_blocked % d_n_passed);
+    d_logger->info("PDU length filter blocked {} and passed {} PDUs",
+                    d_n_blocked,d_n_passed);
     return true;
 }
 
@@ -64,12 +63,12 @@ void pdu_length_filter_impl::handle_pdu(pmt::pmt_t pdu)
 {
     // make sure PDU data is formed properly
     if (!(pmt::is_pair(pdu))) {
-        GR_LOG_WARN(d_logger, "received unexpected PMT (non-pair)");
+        d_logger->warn("received unexpected PMT (non-pair)");
         return;
     }
 
     if (!pmt::is_uniform_vector(pmt::cdr(pdu))) {
-        GR_LOG_WARN(d_logger, "received unexpected PMT (CDR not uniform vector)");
+        d_logger->warn("received unexpected PMT (CDR not uniform vector)");
         return;
     }
 

--- a/lib/pdu_length_filter_impl.cc
+++ b/lib/pdu_length_filter_impl.cc
@@ -13,7 +13,7 @@
 
 #include "pdu_length_filter_impl.h"
 #include <gnuradio/io_signature.h>
-
+#include <boost/format.hpp>
 namespace gr {
 namespace pdu_utils {
 

--- a/lib/pdu_set_m_impl.cc
+++ b/lib/pdu_set_m_impl.cc
@@ -15,7 +15,7 @@
 #include <gnuradio/pdu_utils/pdu_set_m.h>
 #include <gnuradio/io_signature.h>
 #include <algorithm>
-
+#include <boost/format.hpp>
 namespace gr {
 namespace pdu_utils {
 

--- a/lib/pdu_set_m_impl.cc
+++ b/lib/pdu_set_m_impl.cc
@@ -71,21 +71,30 @@ void pdu_set_m_impl::handle_ctrl_msg(pmt::pmt_t msg)
 
     if (pmt::is_pair(msg)) {
         if (pmt::eqv(pmt::car(msg), PMTCONSTSTR__val())) {
-            GR_LOG_NOTICE(d_logger, boost::format("value is %1%") % val());
+            std::ostringstream msgx;
+            msgx << "value is %1%" << val();
+            d_logger->notice(msgx.str());
         } else if (pmt::eqv(pmt::car(msg), PMTCONSTSTR__key())) {
-            GR_LOG_NOTICE(d_logger, boost::format("key is %1%") % key());
+            std::ostringstream msgx;
+            msgx << "key is %1%" << key();
+            d_logger->notice(msgx.str());
         } else if (pmt::eqv(pmt::car(msg), PMTCONSTSTR__set_val())) {
             set_val(pmt::cdr(msg));
-            GR_LOG_NOTICE(d_logger, boost::format("value set to %1%") % val());
+            std::ostringstream msgx;
+            msgx << "value set to %1%" << val();
+            d_logger->notice(msgx.str());
         } else if (pmt::eqv(pmt::car(msg), PMTCONSTSTR__set_key())) {
             set_key(pmt::cdr(msg));
-            GR_LOG_DEBUG(d_logger, boost::format("key set to %1%") % key());
+            std::ostringstream msgx;
+            msgx << "key set to %1%" << key();
+            d_logger->debug(msgx.str());
         } else {
-            GR_LOG_WARN(d_logger,
-                        boost::format("invalid command %1% received...") % pmt::car(msg));
+            std::ostringstream msgx;
+            msgx << "invalid command %1% received..." << pmt::car(msg);
+            d_logger->warn(msgx.str());
         }
     } else {
-        GR_LOG_WARN(d_logger, "received unexpected PMT command (non-pair)");
+        d_logger->warn( "received unexpected PMT command (non-pair)");
     }
 }
 
@@ -94,7 +103,7 @@ void pdu_set_m_impl::handle_msg(pmt::pmt_t pdu)
 {
     // make sure PDU data is formed properly
     if (!(pmt::is_pair(pdu))) {
-        GR_LOG_WARN(d_logger, "received unexpected PMT (non-pair)");
+        d_logger->warn("received unexpected PMT (non-pair)");
         return;
     }
 
@@ -104,12 +113,12 @@ void pdu_set_m_impl::handle_msg(pmt::pmt_t pdu)
     pmt::pmt_t meta = pmt::car(pdu);
 
     if (!pmt::is_dict(meta)) {
-        GR_LOG_WARN(d_logger, "received malformed PDU");
+        d_logger->warn("received malformed PDU");
         return;
     }
 
     if (!d_v_overwrite && pmt::dict_has_key(meta, d_k)) {
-        GR_LOG_WARN(d_logger, "key already found, and overwrite disabled");
+        d_logger->warn("key already found, and overwrite disabled");
         return;
     }
 
@@ -142,7 +151,7 @@ pmt::pmt_t pdu_set_m_impl::parse_val(pmt::pmt_t dict)
 
         // if right brace appears before left brace, invalid syntax
         if (in_val.find('}') < in_val.find('{')) {
-            GR_LOG_WARN(d_logger, "unable to parse val string");
+            d_logger->warn("unable to parse val string");
             return dict;
         }
         // read up to first brace and add to output string
@@ -151,7 +160,7 @@ pmt::pmt_t pdu_set_m_impl::parse_val(pmt::pmt_t dict)
         in_val.erase(0, in_val.find('{')+1);
         // if there's no right brace after a left brace, invalid syntax
         if (in_val.find('}') > in_val.size()) {
-            GR_LOG_WARN(d_logger, "unable to parse val string");
+            d_logger->warn("unable to parse val string");
             return dict;
         }
 
@@ -175,7 +184,7 @@ pmt::pmt_t pdu_set_m_impl::parse_val(pmt::pmt_t dict)
         } else if (pmt::is_symbol(refval)) {
             out_val += pmt::symbol_to_string(refval);
         } else {
-            GR_LOG_WARN(d_logger, boost::format("value type of %1% not supported") % tmp);
+            d_logger->warn("value type of {} not supported",tmp);
             out_val += tmp;
         }
     }

--- a/lib/pdu_to_bursts_impl.cc
+++ b/lib/pdu_to_bursts_impl.cc
@@ -98,7 +98,7 @@ void pdu_to_bursts_impl<T>::store_pdu(pmt::pmt_t pdu)
     // check and see if there is already data in the vector, drop if in drop mode
     if (d_drop_early_bursts & (d_data.size() | d_pdu_queue.size())) {
         if (d_early_burst_err) {
-            GR_LOG_ERROR(this->d_logger,
+            this->d_logger->error(
                          "PDU received before previous burst finished writing - dropped");
         }
         return;
@@ -106,7 +106,7 @@ void pdu_to_bursts_impl<T>::store_pdu(pmt::pmt_t pdu)
 
     // make sure PDU data is formed properly
     if (!(pmt::is_pair(pdu))) {
-        GR_LOG_ERROR(this->d_logger, "received unexpected PMT (non-pair)");
+        this->d_logger->error("received unexpected PMT (non-pair)");
         return;
     }
 
@@ -114,16 +114,15 @@ void pdu_to_bursts_impl<T>::store_pdu(pmt::pmt_t pdu)
     pmt::pmt_t v_data = pmt::cdr(pdu);
 
     if (!(is_dict(meta) && pmt::is_uniform_vector(v_data))) {
-        GR_LOG_ERROR(this->d_logger, "PMT is not a PDU, dropping");
+        this->d_logger->error("PMT is not a PDU, dropping");
         return;
     }
 
     if (pmt::length(v_data) != 0) {
         size_t v_itemsize = pmt::uniform_vector_itemsize(v_data);
         if (v_itemsize != d_itemsize) {
-            GR_LOG_ERROR(this->d_logger,
-                         boost::format("PDU received has incorrect itemsize (%d != %d)") %
-                             v_itemsize % d_itemsize);
+            this->d_logger->error("PDU received has incorrect itemsize ({} != {})",
+                             v_itemsize, d_itemsize);
             return;
         }
 
@@ -133,14 +132,13 @@ void pdu_to_bursts_impl<T>::store_pdu(pmt::pmt_t pdu)
             d_drop_ctr = 0;
         } else {
             d_drop_ctr++;
-            GR_LOG_WARN(this->d_logger,
-                        boost::format("Queue full, PDU dropped (%d dropped so far)") %
+            this->d_logger->warn("Queue full, PDU dropped ({} dropped so far)",
                             d_drop_ctr);
         }
         // std::cout << "Now there are " << d_pdu_queue.size() << " items in the PDU
         // queue" << std::endl;
     } else {
-        GR_LOG_WARN(this->d_logger, "zero size PDU ignored");
+        this->d_logger->warn("zero size PDU ignored");
     }
 
     return;

--- a/lib/pdu_to_bursts_impl.cc
+++ b/lib/pdu_to_bursts_impl.cc
@@ -16,7 +16,7 @@
 
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread/thread.hpp>
-
+#include <boost/format.hpp>
 namespace gr {
 namespace pdu_utils {
 

--- a/lib/tag_message_trigger_impl.cc
+++ b/lib/tag_message_trigger_impl.cc
@@ -13,7 +13,7 @@
 
 #include "tag_message_trigger_impl.h"
 #include <gnuradio/io_signature.h>
-
+#include <boost/format.hpp>
 namespace gr {
 namespace pdu_utils {
 

--- a/lib/tag_message_trigger_impl.cc
+++ b/lib/tag_message_trigger_impl.cc
@@ -69,21 +69,17 @@ tag_message_trigger_impl<T>::tag_message_trigger_impl(pmt::pmt_t trigger_key,
     set_holdoff(holdoff);
 
     if (d_tpdu_mode) {
-        GR_LOG_NOTICE(this->d_logger,
-                      boost::format("started at time %f in timed PDU mode") % start_time);
+        this->d_logger->notice("started at time {:e} in timed PDU mode",start_time);
     } else {
-        GR_LOG_NOTICE(this->d_logger,
-                      boost::format("started at time %f in normal message mode") %
+        this->d_logger->notice("started at time {:e} in normal message mode",
                           start_time);
     }
 
     if (pmt::eq(d_arming_key, pmt::PMT_NIL)) {
-        GR_LOG_WARN(this->d_logger, "operating in always armed mode");
+        this->d_logger->warn("operating in always armed mode");
         d_fire_at_will = true;
     } else {
-        GR_LOG_WARN(this->d_logger,
-                    boost::format("operating with arming key \"%s\"") %
-                        pmt::symbol_to_string(arming_key));
+        this->d_logger->warn("operating with arming key {}", pmt::symbol_to_string(arming_key));
     }
 
     this->message_port_register_in(PMTCONSTSTR__ctrl());
@@ -205,7 +201,7 @@ int tag_message_trigger_impl<T>::work(int noutput_items,
 
                 // if we have reached the transmit limit, disarm and continue
                 if (d_tx_limit == 0) {
-                    GR_LOG_NOTICE(this->d_logger, "not firing, TX Limit reached");
+                    this->d_logger->notice( "not firing, TX Limit reached");
                     d_armed = false;
 
                     // otherwise fire the burst
@@ -266,10 +262,7 @@ int tag_message_trigger_impl<T>::work(int noutput_items,
 
                 // we aren't armed, do nothing
             } else {
-                GR_LOG_INFO(
-                    this->d_logger,
-                    boost::format("trigger received at offset %d but not ready to fire") %
-                        d_tag.offset);
+                    this->d_logger->info("trigger received at offset {} but not ready to fire",d_tag.offset);
             }
 
             // if we get a rx_time tag from the USRP, use that to set timing offsets
@@ -277,9 +270,8 @@ int tag_message_trigger_impl<T>::work(int noutput_items,
             set_known_time_offset(pmt::to_uint64(pmt::tuple_ref(d_tag.value, 0)),
                                   pmt::to_double(pmt::tuple_ref(d_tag.value, 1)),
                                   d_tag.offset);
-            GR_LOG_INFO(this->d_logger,
-                        boost::format("got a time update ({%d  %f} at %d)") %
-                            d_known_time_int_sec % d_known_time_frac_sec %
+            this->d_logger->info("got a time update ({{}  {:e}} at {})",
+                            d_known_time_int_sec,d_known_time_frac_sec,
                             d_known_time_offset);
         }
     }

--- a/lib/tags_to_pdu_impl.cc
+++ b/lib/tags_to_pdu_impl.cc
@@ -13,7 +13,7 @@
 
 #include "tags_to_pdu_impl.h"
 #include <gnuradio/io_signature.h>
-
+#include <boost/format.hpp>
 namespace gr {
 namespace pdu_utils {
 

--- a/lib/tags_to_pdu_impl.cc
+++ b/lib/tags_to_pdu_impl.cc
@@ -73,7 +73,7 @@ tags_to_pdu_impl<T>::tags_to_pdu_impl(pmt::pmt_t start_tag,
     this->d_logger->notice("starting at time ({} {:e})",d_known_time_int_sec,
                       d_known_time_frac_sec);
 
-    this->d_logger->notice("rate {+12e}",d_samp_rate);
+    this->d_logger->notice("rate {:0.12f}",d_samp_rate);
 
     // store the data to prepend
     // d_prepend.clear();

--- a/lib/tags_to_pdu_impl.cc
+++ b/lib/tags_to_pdu_impl.cc
@@ -70,11 +70,10 @@ tags_to_pdu_impl<T>::tags_to_pdu_impl(pmt::pmt_t start_tag,
     // parameter
     set_start_time(start_time);
     set_eob_parameters(1, 0);
-    GR_LOG_NOTICE(this->d_logger,
-                  boost::format("starting at time {%d %f}") % d_known_time_int_sec %
+    this->d_logger->notice("starting at time ({} {:e})",d_known_time_int_sec,
                       d_known_time_frac_sec);
 
-    GR_LOG_NOTICE(this->d_logger, boost::format("rate %0.12f") % d_samp_rate);
+    this->d_logger->notice("rate {+12e}",d_samp_rate);
 
     // store the data to prepend
     // d_prepend.clear();
@@ -109,7 +108,7 @@ void tags_to_pdu_impl<T>::handle_ctrl_msg(pmt::pmt_t ctrl_msg)
         ctrl_msg = pmt::car(ctrl_msg);
     } catch (const pmt::wrong_type& e) {
         // So we fix it:
-        GR_LOG_WARN(this->d_logger, "got a pair, not a dict, fixing");
+        this->d_logger->warn("got a pair, not a dict, fixing");
         ctrl_msg =
             pmt::dict_add(pmt::make_dict(), pmt::car(ctrl_msg), pmt::cdr(ctrl_msg));
     }
@@ -121,9 +120,7 @@ void tags_to_pdu_impl<T>::handle_ctrl_msg(pmt::pmt_t ctrl_msg)
         uint32_t new_eob_offset = pmt::to_uint64(pmt::dict_ref(
             ctrl_msg, PMTCONSTSTR__eob_offset(), pmt::from_uint64(d_eob_offset)));
         set_eob_parameters(d_eob_alignment, new_eob_offset);
-        GR_LOG_NOTICE(
-            this->d_logger,
-            boost::format("command received - set EOB tag offset to %d symbols") %
+        this->d_logger->notice("command received - set EOB tag offset to {} symbols",
                 d_eob_offset);
     }
 
@@ -133,14 +130,11 @@ void tags_to_pdu_impl<T>::handle_ctrl_msg(pmt::pmt_t ctrl_msg)
             ctrl_msg, PMTCONSTSTR__eob_alignment(), pmt::from_uint64(d_eob_alignment)));
         if (new_eob_alignment > 0) {
             set_eob_parameters(new_eob_alignment, d_eob_offset);
-            GR_LOG_NOTICE(
-                this->d_logger,
-                boost::format("command received - set EOB tag alignment to %d symbols") %
+            this->d_logger->notice("command received - set EOB tag alignment to {} symbols",
                     d_eob_alignment);
         } else {
-            GR_LOG_ERROR(this->d_logger,
-                         boost::format("command received - illegal value %d for EOB "
-                                       "alignment, not setting") %
+            this->d_logger->error("command received - illegal value {} for EOB "
+                                       "alignment, not setting",
                              new_eob_alignment);
         }
     }
@@ -273,10 +267,9 @@ int tags_to_pdu_impl<T>::work(int noutput_items,
 
                 // if we have received a second SOB tag, reset and dump previous data
             } else if (d_tag_type == SOB) {
-                GR_LOG_ERROR(this->d_logger,
-                             boost::format("SOB tag received during burst %d at offset "
-                                           "%d, previous burst dropped (%d tags total)") %
-                                 d_burst_counter % d_tag.offset % d_tags.size());
+                this->d_logger->error("SOB tag received during burst {} at offset "
+                                           "{}, previous burst dropped ({} tags total)",
+                                 d_burst_counter,d_tag.offset,d_tags.size());
 
                 // prepare for next burst
                 d_burst_counter++;
@@ -323,8 +316,7 @@ int tags_to_pdu_impl<T>::work(int noutput_items,
         } else if (d_tag_type == EOB) {
             // receiving an EOB sequence while not triggered is just random chance. No
             // warning necessary...
-            GR_LOG_INFO(this->d_logger,
-                        boost::format("received unexpected EOB at offset %d") %
+            this->d_logger->info("received unexpected EOB at offset {}",
                             d_tag.offset);
 
         } else {

--- a/lib/take_skip_to_pdu_impl.cc
+++ b/lib/take_skip_to_pdu_impl.cc
@@ -40,12 +40,11 @@ take_skip_to_pdu_impl<T>::take_skip_to_pdu_impl(uint32_t take, uint32_t skip)
       d_prev_byte(0)
 {
     if (d_take == 0) {
-        GR_LOG_FATAL(this->d_logger, "TAKE value too small, must be > 0");
+        this->d_logger->fatal("TAKE value too small, must be > 0");
         throw std::invalid_argument("TAKE value out of bounds");
     }
     if (d_take > TAKESKIP_MAXIMUM_PDU_SIZE) {
-        GR_LOG_FATAL(this->d_logger,
-                     boost::format("TAKE value too large, must be less than %d") %
+        this->d_logger->fatal("TAKE value too large, must be less than {}",
                          TAKESKIP_MAXIMUM_PDU_SIZE);
         throw std::invalid_argument("TAKE value out of bounds");
     }

--- a/lib/take_skip_to_pdu_impl.cc
+++ b/lib/take_skip_to_pdu_impl.cc
@@ -13,8 +13,7 @@
 
 #include "take_skip_to_pdu_impl.h"
 #include <gnuradio/io_signature.h>
-//#include <pmt/pmt.h>
-
+#include <boost/format.hpp>
 namespace gr {
 namespace pdu_utils {
 

--- a/lib/upsample_impl.cc
+++ b/lib/upsample_impl.cc
@@ -50,7 +50,7 @@ void upsample_impl::handle_msg(pmt::pmt_t pdu)
 {
     // make sure PDU data is formed properly
     if (!(pmt::is_pair(pdu))) {
-        GR_LOG_NOTICE(d_logger, boost::format("received unexpected PMT (non-pair)"));
+        d_logger->notice("received unexpected PMT (non-pair)");
         return;
     }
 
@@ -66,7 +66,7 @@ void upsample_impl::handle_msg(pmt::pmt_t pdu)
     pmt::pmt_t v_data = pmt::cdr(pdu);
 
     if (!(is_dict(meta) && pmt::is_uniform_vector(v_data))) {
-        GR_LOG_NOTICE(d_logger, "received unexpected PMT (non-PDU)");
+        d_logger->notice("received unexpected PMT (non-PDU)");
         return;
     }
 
@@ -299,12 +299,12 @@ void upsample_impl::handle_msg(pmt::pmt_t pdu)
                          pmt::cons(meta, pmt::init_c32vector(output.size(), output)));
     } else if (pmt::is_c64vector(v_data)) {
         // TODO: support this...
-        GR_LOG_NOTICE(d_logger, "PDU of type complex double not supported, dropped");
+        d_logger->notice("PDU of type complex double not supported, dropped");
         return;
 
     } else {
         // drop message and return
-        GR_LOG_NOTICE(d_logger, "unknown PDU vector type, dropped");
+        d_logger->notice("unknown PDU vector type, dropped");
         return;
     }
     return;

--- a/lib/upsample_impl.cc
+++ b/lib/upsample_impl.cc
@@ -13,7 +13,7 @@
 
 #include "upsample_impl.h"
 #include <gnuradio/io_signature.h>
-
+#include <boost/format.hpp>
 namespace gr {
 namespace pdu_utils {
 


### PR DESCRIPTION
This fixes the missing boost format imports that will lead to compilation errors if missing on gnuradio 3.10 / ubuntu 22.04 lts