### PR TITLE
Change assertEquals to assertEqual

### DIFF
--- a/python/pdu_utils/qa_message_emitter.py
+++ b/python/pdu_utils/qa_message_emitter.py
@@ -47,8 +47,8 @@ class qa_message_emitter (gr_unittest.TestCase):
         self.tb.wait()
         
         
-        self.assertEquals(3, debug.num_messages())
-        self.assertEquals(3, emitter.get_n_msgs() )
+        self.assertEqual(3, debug.num_messages())
+        self.assertEqual(3, emitter.get_n_msgs() )
 
     def test_002_emit2 (self):
         emitter = pdu_utils.message_emitter()
@@ -66,8 +66,8 @@ class qa_message_emitter (gr_unittest.TestCase):
         self.tb.wait()
 
         print(emitter.get_n_msgs())
-        self.assertEquals(2, debug.num_messages())
-        self.assertEquals(2, emitter.get_n_msgs() )
+        self.assertEqual(2, debug.num_messages())
+        self.assertEqual(2, emitter.get_n_msgs() )
         self.assertTrue(pmt.eqv(pmt.PMT_NIL, debug.get_message(0)))
         self.assertTrue(pmt.eqv(msg, debug.get_message(1)))
 

--- a/python/pdu_utils/qa_message_gate.py
+++ b/python/pdu_utils/qa_message_gate.py
@@ -42,8 +42,8 @@ class qa_message_gate (gr_unittest.TestCase):
         self.tb.stop()
         self.tb.wait()
 
-        self.assertEquals(4, gate.get_n_passed())
-        self.assertEquals(4, debug.num_messages())
+        self.assertEqual(4, gate.get_n_passed())
+        self.assertEqual(4, debug.num_messages())
 
     def test_002_2x_pass_3x_block (self):
         strobe = blocks.message_strobe(pmt.PMT_NIL, 25)
@@ -59,9 +59,9 @@ class qa_message_gate (gr_unittest.TestCase):
         self.tb.stop()
         self.tb.wait()
 
-        self.assertEquals(2, gate.get_n_passed())
-        self.assertEquals(2, debug.num_messages())
-        self.assertEquals(3, gate.get_n_blocked())
+        self.assertEqual(2, gate.get_n_passed())
+        self.assertEqual(2, debug.num_messages())
+        self.assertEqual(3, gate.get_n_blocked())
 
 
 if __name__ == '__main__':

--- a/python/pdu_utils/qa_message_keep_1_in_n.py
+++ b/python/pdu_utils/qa_message_keep_1_in_n.py
@@ -45,7 +45,7 @@ class qa_message_keep_1_in_n (gr_unittest.TestCase):
         self.tb.stop()
         self.tb.wait()
 
-        self.assertEquals(1, debug.num_messages())
+        self.assertEqual(1, debug.num_messages())
 
 
     def test_002_send8_keep4 (self):
@@ -63,7 +63,7 @@ class qa_message_keep_1_in_n (gr_unittest.TestCase):
         self.tb.stop()
         self.tb.wait()
 
-        self.assertEquals(4, debug.num_messages())
+        self.assertEqual(4, debug.num_messages())
 
 
 if __name__ == '__main__':

--- a/python/pdu_utils/qa_tag_message_trigger.py
+++ b/python/pdu_utils/qa_tag_message_trigger.py
@@ -47,7 +47,7 @@ class qa_tag_message_trigger (gr_unittest.TestCase):
         self.tb.msg_connect((tmt, 'msg'), (debug, 'store'))
         self.tb.run ()
 
-        self.assertEquals(debug.num_messages(),2)
+        self.assertEqual(debug.num_messages(),2)
         self.assertTrue(pmt.eqv(msg, debug.get_message(0)))
 
         self.tb = None
@@ -74,7 +74,7 @@ class qa_tag_message_trigger (gr_unittest.TestCase):
         self.tb.msg_connect((tmt, 'msg'), (debug, 'store'))
         self.tb.run ()
 
-        self.assertEquals(debug.num_messages(),3)
+        self.assertEqual(debug.num_messages(),3)
         self.assertTrue(pmt.eqv(msg, debug.get_message(0)))
         self.assertTrue(pmt.eqv(msg, debug.get_message(1)))
 
@@ -100,7 +100,7 @@ class qa_tag_message_trigger (gr_unittest.TestCase):
         self.tb.msg_connect((tmt, 'msg'), (debug, 'store'))
         self.tb.run ()
 
-        self.assertEquals(debug.num_messages(),2)
+        self.assertEqual(debug.num_messages(),2)
         self.assertTrue(pmt.eqv(msg, debug.get_message(0)))
         self.assertTrue(pmt.eqv(msg, debug.get_message(1)))
 
@@ -133,7 +133,7 @@ class qa_tag_message_trigger (gr_unittest.TestCase):
         self.tb.msg_connect((tmt, 'msg'), (debug, 'store'))
         self.tb.run ()
 
-        self.assertEquals(debug.num_messages(),3)
+        self.assertEqual(debug.num_messages(),3)
         self.assertTrue(pmt.eqv(msg, debug.get_message(0)))
         self.assertTrue(pmt.eqv(msg, debug.get_message(1)))
 


### PR DESCRIPTION
Because assertEquals has been deprecated since Python 3.2 and removed in Python 3.12, this changes every instances of assertEquals to assertEqual.  This fixes issue #24.