### PR TITLE
Fix invalid escape string in regex

### DIFF
--- a/python/pdu_utils/qt_pdu_source.py
+++ b/python/pdu_utils/qt_pdu_source.py
@@ -135,7 +135,7 @@ class qt_pdu_source(gr.sync_block, QGroupBox):
 
     def parse_byte_array(self,v_txt):
         vec = []
-        for entry in re.split('\D',v_txt):
+        for entry in re.split(r'\D',v_txt):
             try:
                 item = int(entry)
                 vec.append(item)


### PR DESCRIPTION
Before Python version 3.8, an invalid escape sequence was silently ignored.  Python versions 3.8 and later issue a warning for an invalid escape sequence, which was how this was discovered.  This fixes the regex by making it a raw string.